### PR TITLE
Switch extension redirect domain to freedium-mirror.cfd

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Contributions are welcome! Please feel free to file a bug report and/or submit a
 
 ## Acknowledgements
 
-This extension wouldn't be possible without [Freedium](https://freedium.cfd), which provides the service to read Medium articles without a paywall. If you find this extension useful, please consider supporting [Freedium](https://freedium.cfd) by donating to help maintain their service
+This extension wouldn't be possible without [Freedium](https://freedium-mirror.cfd), which provides the service to read Medium articles without a paywall. If you find this extension useful, please consider supporting [Freedium](https://freedium-mirror.cfd) by donating to help maintain their service

--- a/Shared (Extension)/Resources/content.js
+++ b/Shared (Extension)/Resources/content.js
@@ -56,7 +56,7 @@ const handleArticleRedirect = () => {
         });
         
         // Construct the Freedium URL
-        const freediumUrl = `https://freedium.cfd/${window.location.href}`;
+        const freediumUrl = `https://freedium-mirror.cfd/${window.location.href}`;
         
         // Redirect to Freedium
         window.location.href = freediumUrl;
@@ -88,7 +88,7 @@ document.addEventListener('click', (event) => {
                     event.preventDefault();
                     
                     // Construct the Freedium URL
-                    const freediumUrl = `https://freedium.cfd/${link.href}`;
+                    const freediumUrl = `https://freedium-mirror.cfd/${link.href}`;
                     
                     // Navigate to Freedium
                     window.location.href = freediumUrl;


### PR DESCRIPTION
This pull request updates the extension to use a new Freedium mirror service for accessing Medium articles. All references and redirect URLs have been switched from the old Freedium domain to the new mirror.

Domain migration to new Freedium mirror:

* Updated all redirect URLs in `content.js` to use `https://freedium-mirror.cfd` instead of `https://freedium.cfd`, ensuring the extension continues to function with the new service endpoint. [[1]](diffhunk://#diff-fa275b2a52b72786fc5d483e841b3e7c69a3782aa7718089c64eaa51db9495e2L59-R59) [[2]](diffhunk://#diff-fa275b2a52b72786fc5d483e841b3e7c69a3782aa7718089c64eaa51db9495e2L91-R91)
* Updated the Freedium service link in the `README.md` acknowledgements section to point to `https://freedium-mirror.cfd`.